### PR TITLE
Loosen path segment regex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ macro_rules! router {
             s.push('/');
             let path_segment = stringify!($path_segment);
             if path_segment.starts_with('{') {
-                s.push_str(r#"([\w-]+)"#);
+                s.push_str(r#"([^/?#]+)"#);
             } else {
                 s.push_str(path_segment);
             }


### PR DESCRIPTION
Had a requirement to support things like `%20` in dynamic path segments which would previously always hit the default route.

I just expanded the regex to be very permissive. It might make sense to also percent decode it, but maybe outside the scope of this library.